### PR TITLE
Comm integration testing

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 These instructions are for installing and running the application in development mode on a development machine. There are two installation methods below, one uses [docker](https://www.docker.com/) and the other is manual. The docker installation is the recommended method.
 
 ## Docker Installation - Website and Satellite Simulator (Recommended)
-The docker installation methods below are compatible with any operating system that is supported by [docker](https://www.docker.com/). If you are just looking to use the web app and don't plan on making any changes to the source code, then choose the `User Installation` method below. Otherwise, choose the `Developer Installation` method below. 
+The docker installation methods below are compatible with any operating system that is supported by [docker](https://www.docker.com/). If you are just looking to use the web app and don't plan on making any changes to the source code, then choose the `User Installation` method below. Otherwise, choose the `Developer Installation` method below.
 
 Prior to starting, please [install docker](https://www.docker.com/get-started) for your operating system if you have not already.
 
@@ -19,7 +19,7 @@ docker run --rm -it -p 8000:8000 albertasatdocker/ground-station-website:user-la
 Now, open Google Chrome and navigate to [http://localhost:8000](http://localhost:8000).
 
 ## Developer Installation
-This installation method it will allow you to immediately see any modifications you have made to the source code on your host machine in the docker container (and vice versa). As a result, you will not have to rebuild the docker image every time you make a change to the source code on your host machine. 
+This installation method it will allow you to immediately see any modifications you have made to the source code on your host machine in the docker container (and vice versa). As a result, you will not have to rebuild the docker image every time you make a change to the source code on your host machine.
 
 ### MacOS and Ubuntu
 
@@ -108,7 +108,7 @@ Ubuntu dependencies for PostgreSQL, libCSP, and scheduling tasks:
 sudo apt-get install at build-essential wget curl libpq-dev python3-dev gcc-multilib g++-multilib libsocketcan-dev
 ```
 
-To run the app's frontend (i.e. in your web browser), you will need node & npm -- at least version 8. I recommend using the [Node Version Manager](https://github.com/nvm-sh/nvm). 
+To run the app's frontend (i.e. in your web browser), you will need node & npm -- at least version 8. I recommend using the [Node Version Manager](https://github.com/nvm-sh/nvm).
 
 Make sure you have a [Python virtual environment](https://docs.python.org/3/tutorial/venv.html) installed and active! To do this navigate to the root project directory and run the following commands:
 
@@ -127,7 +127,7 @@ Install pip and npm libraries by running `update.sh`.
 
 ```bash
 source ./update.sh
-```  
+```
 
 Finally, run the app.
 
@@ -156,3 +156,5 @@ These commands should be the same regardless of which method of installation you
 * `python3 manage.py test` - run the unit tests.
 
 * `python3 manage.py test frontend_test` - run the GUI frontend tests with Selenium. Please note that you will need to install the appropriate driver [here](https://selenium-python.readthedocs.io/installation.html#drivers).
+
+* `python3 manage.py test groundstation_test` - run ground station integration testing. Please note that you will need to have built libcsp in this repo's submodule and have set the appropriate env variables with `source ./env.sh`

--- a/build_libcsp.sh
+++ b/build_libcsp.sh
@@ -5,8 +5,6 @@
 git submodule update --init --recursive
 
 # Fetch libcsp dependencies
-# NOTE: Python is required but not installed here as to not interfere
-# with the setup-python Github Action
 sudo apt update
 sudo apt install at \
     build-essential \
@@ -17,7 +15,9 @@ sudo apt install at \
     libsocketcan-dev \
     pkg-config \
     gcc-multilib \
-    g++-multilib -y
+    g++-multilib \
+    python3-dev \
+    python3-pip -y
 
 # Configure libcsp
 # (Configuration flags taken from ex2_ground_station_software)

--- a/build_libcsp.sh
+++ b/build_libcsp.sh
@@ -2,7 +2,7 @@
 # For Ubuntu
 
 # Fetch submodules
-git submodules update --init --recursive
+git submodule update --init --recursive
 
 # Fetch libcsp dependencies
 # NOTE: Python is required but not installed here as to not interfere

--- a/build_libcsp.sh
+++ b/build_libcsp.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# For Ubuntu
+
+# Fetch submodules
+git submodules update --init --recursive
+
+# Fetch libcsp dependencies
+# NOTE: Python is required but not installed here as to not interfere
+# with the setup-python Github Action
+sudo apt install at \
+    build-essential \
+    wget \
+    curl \
+    libpq-dev \
+    libzmq3-dev \
+    libsocketcan-dev \
+    pkg-config \
+    gcc-multilib \
+    g++-multilib -y
+
+# Configure libcsp
+cd libcsp
+python3 waf configure --with-os=posix --enable-can-socketcan --enable-rdp --enable-crc32 --enable-hmac --enable-xtea --with-loglevel=debug --enable-debug-timestamp --enable-python3-bindings --with-driver-usart=linux --enable-if-zmqhub --enable-examples
+python3 waf build
+cd ..

--- a/build_libcsp.sh
+++ b/build_libcsp.sh
@@ -7,6 +7,7 @@ git submodule update --init --recursive
 # Fetch libcsp dependencies
 # NOTE: Python is required but not installed here as to not interfere
 # with the setup-python Github Action
+sudo apt update
 sudo apt install at \
     build-essential \
     wget \
@@ -19,6 +20,7 @@ sudo apt install at \
     g++-multilib -y
 
 # Configure libcsp
+# (Configuration flags taken from ex2_ground_station_software)
 cd libcsp
 python3 waf configure --with-os=posix --enable-can-socketcan --enable-rdp --enable-crc32 --enable-hmac --enable-xtea --with-loglevel=debug --enable-debug-timestamp --enable-python3-bindings --with-driver-usart=linux --enable-if-zmqhub --enable-examples
 python3 waf build

--- a/comm.py
+++ b/comm.py
@@ -92,9 +92,8 @@ def send_to_simulator(msg):
 
 def send_to_satellite(sock, csp, msg):
     try:
-        to_send, server, port = csp.getInput(inVal=msg)
-        csp.send(server, port, to_send)
-        return csp.receive(sock)
+        server, port, toSend = csp.getInput(inVal=msg)
+        return csp.transaction(server, port, toSend)
     except Exception as e:
         print('Unexpected error occured:', e)
 

--- a/comm.py
+++ b/comm.py
@@ -1,5 +1,5 @@
 """
-The Communications Module is responsible for sending and retrieving data 
+The Communications Module is responsible for sending and retrieving data
 with the satellite (or the simulator).
 """
 
@@ -32,7 +32,7 @@ def handler(signum, frame):
 
 def handle_message(message):
     """
-    Messages sent to comm will pass through this function, essentially acting 
+    Messages sent to comm will pass through this function, essentially acting
     as a decorator.
 
     TODO: this needs to be implmented to support flight schedule functionality.
@@ -48,7 +48,7 @@ def handle_message(message):
     }
 
     handle = gs_commands.get(message)
-    
+
     if handle:
         return handle()
     else:
@@ -57,10 +57,10 @@ def handle_message(message):
 
 def upload_fs():
     """
-    If there is no queued flightschedule log it, otherwise, set its status 
+    If there is no queued flightschedule log it, otherwise, set its status
     to uploaded and send something to the flight schedule (this may be handled
-    differently right now we are blindly trusting that a sent flightschedule 
-    is uploaded) and no data of the flight schedule is actually sent at the 
+    differently right now we are blindly trusting that a sent flightschedule
+    is uploaded) and no data of the flight schedule is actually sent at the
     moment.
 
     TODO: this needs to be implemented properly.
@@ -114,7 +114,7 @@ def save_response(message):
 
 def communication_loop(sock=None, csp=None):
     """
-    Main communication loop which polls for messages that are queued and addressed to comm 
+    Main communication loop which polls for messages that are queued and addressed to comm
     (i.e. messages it needs to send to satellite). This should be run when a passover is
     expected to occur.
 
@@ -151,12 +151,12 @@ def communication_loop(sock=None, csp=None):
                                 save_response(item)
                         else:
                             save_response(response)
-                        
+
                         # Denote that the message has been executed if successful
                         communication_patch.patch(
-                            message['message_id'], 
+                            message['message_id'],
                             local_data=json.dumps({'is_queued': False}))
-        
+
         time.sleep(5)
 
 
@@ -169,21 +169,21 @@ def main():
         communication_loop()
     elif mode == Connection.SATELLITE:
         # TODO maybe clean up by putting in a function in gs_software
-        opts = gs_software.getOptions()
-        csp = gs_software.Csp(opts)
+        opts = gs_software.groundStation.options()
+        csp = gs_software.groundStation.groundStation(opts)
         sock = libcsp.socket()
         libcsp.bind(sock, libcsp.CSP_ANY)
         communication_loop(sock, csp)
 
 
 if __name__ == '__main__':
-    if input('Would like to communicate with the satellite simulator (if not, the program ' 
+    if input('Would like to communicate with the satellite simulator (if not, the program '
         'will attempt to communicate with the satellite) [Y/n]: ').strip() in ('Y', 'y'):
         mode = Connection.SIMULATOR
         import satellite_simulator.antenna as antenna
     else:
         mode = Connection.SATELLITE
-        import ex2_ground_station_software.src.groundstation as gs_software
+        import ex2_ground_station_software.src.groundStation as gs_software
         import libcsp.build.libcsp_py3 as libcsp
 
     main()

--- a/comm.py
+++ b/comm.py
@@ -91,7 +91,8 @@ def send_to_simulator(msg):
 
 def convert_command_syntax(cmd):
     """
-    Converts website command syntax to ground station software's syntax.
+    Takes in a website command and converts it to ground station software's
+    syntax.
 
     Currently, the website's command syntax is:
         `command.name arg1 arg2 ...`

--- a/comm.py
+++ b/comm.py
@@ -89,10 +89,29 @@ def send_to_simulator(msg):
     except Exception as e:
         print('Unexpected error occured:', e)
 
+def convert_command_syntax(cmd: str):
+    """
+    Converts website command syntax to ground station software's syntax.
+
+    Currently, the website's command syntax is:
+        `command.name arg1 arg2 ...`
+    but ground station software's command syntax is:
+        `command.name(arg1 arg2 ...)`
+
+    TODO: Eventually, change the "Live Commands" syntax on the website
+          to match ground station software's for consistency.
+
+    :param str cmd: A command entered from the website.
+    :returns: The same command but in ground station software's syntax.
+    :rtype: str
+    """
+    tokens = cmd.split()
+    return tokens[0] + '(' + ' '.join(tokens[1:]) + ')'
 
 def send_to_satellite(sock, csp, msg):
     try:
-        server, port, toSend = csp.getInput(inVal=msg)
+        command = convert_command_syntax(msg)
+        server, port, toSend = csp.getInput(inVal=command)
         return csp.transaction(server, port, toSend)
     except Exception as e:
         print('Unexpected error occured:', e)

--- a/comm.py
+++ b/comm.py
@@ -89,7 +89,7 @@ def send_to_simulator(msg):
     except Exception as e:
         print('Unexpected error occured:', e)
 
-def convert_command_syntax(cmd: str):
+def convert_command_syntax(cmd):
     """
     Converts website command syntax to ground station software's syntax.
 

--- a/comm.py
+++ b/comm.py
@@ -110,7 +110,10 @@ def convert_command_syntax(cmd: str):
 
 def send_to_satellite(csp, msg):
     try:
-        server, port, toSend = csp.getInput(inVal=msg)
+        command = csp.getInput(inVal=msg)
+        if command is None:
+            return "INVALID COMMAND"
+        server, port, toSend = command
         return csp.transaction(server, port, toSend)
     except Exception as e:
         print('Unexpected error occured:', e)

--- a/comm.py
+++ b/comm.py
@@ -170,8 +170,11 @@ def main():
         # TODO maybe clean up by putting in a function in gs_software
         opts = gs_software.groundStation.options()
         csp = gs_software.groundStation.groundStation(opts.getOptions())
+
+        # Not sure if this socket is needed here as gs_software already manages it.
         sock = libcsp.socket()
         libcsp.bind(sock, libcsp.CSP_ANY)
+
         communication_loop(sock, csp)
 
 
@@ -183,6 +186,8 @@ if __name__ == '__main__':
     else:
         mode = Connection.SATELLITE
         import ex2_ground_station_software.src.groundStation as gs_software
+
+        # Not sure if this is still needed as gs_software already imports it
         import libcsp.build.libcsp_py3 as libcsp
 
     main()

--- a/comm.py
+++ b/comm.py
@@ -170,7 +170,7 @@ def main():
     elif mode == Connection.SATELLITE:
         # TODO maybe clean up by putting in a function in gs_software
         opts = gs_software.groundStation.options()
-        csp = gs_software.groundStation.groundStation(opts)
+        csp = gs_software.groundStation.groundStation(opts.getOptions())
         sock = libcsp.socket()
         libcsp.bind(sock, libcsp.CSP_ANY)
         communication_loop(sock, csp)

--- a/comm.py
+++ b/comm.py
@@ -110,8 +110,7 @@ def convert_command_syntax(cmd: str):
 
 def send_to_satellite(sock, csp, msg):
     try:
-        command = convert_command_syntax(msg)
-        server, port, toSend = csp.getInput(inVal=command)
+        server, port, toSend = csp.getInput(inVal=msg)
         return csp.transaction(server, port, toSend)
     except Exception as e:
         print('Unexpected error occured:', e)
@@ -156,11 +155,13 @@ def communication_loop(sock=None, csp=None):
 
                     # Send the message to the satellite
                     response = None
-                    msg = message['message'].replace(" ", ".")
+                    msg = message['message']
                     print('Sent:', msg)
                     if mode == Connection.SIMULATOR:
+                        msg = message['message'].replace(" ", ".")
                         response = send_to_simulator(msg)
                     elif mode == Connection.SATELLITE:
+                        msg = convert_command_syntax(msg)
                         response = send_to_satellite(sock, csp, msg)
 
                     if response:

--- a/comm.py
+++ b/comm.py
@@ -99,8 +99,8 @@ def convert_command_syntax(cmd):
     but ground station software's command syntax is:
         `command.name(arg1 arg2 ...)`
 
-    TODO: Eventually, change the "Live Commands" syntax on the website
-          to match ground station software's for consistency.
+    TODO: Change the "Live Commands" syntax on the website
+          to match ground station software's for consistency (Issue #64).
 
     :param str cmd: A command entered from the website.
     :returns: The same command but in ground station software's syntax.

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -11,7 +11,12 @@ RUN apt-get update && apt-get install -y \
   curl \
   git \
   libpq-dev \
-  libffi-dev
+  libffi-dev \
+  libzmq3-dev \
+  libsocketcan-dev \
+  pkg-config \
+  gcc-multilib \
+  g++-multilib
 
 # install python
 RUN apt-get update && apt-get install -y \
@@ -22,9 +27,9 @@ WORKDIR /usr/local/bin
 RUN ln -s /usr/bin/python3 python \
   && pip3 install --upgrade pip
 
-# copy our repo to the image
+# install python dependencies
 WORKDIR /home/ex2_ground_station_website
-COPY requirements.txt . 
+COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 RUN rm requirements.txt
 
@@ -40,8 +45,10 @@ ENV FLASK_APP=groundstation/__init__.py
 ENV FLASK_ENV=development
 ENV APP_SETTINGS=groundstation.config.DevelopmentConfig
 ENV SECRET_KEY="\xffY\x8dG\xfbu\x96S\x86\xdfu\x98\xe8S\x9f\x0e\xc6\xde\xb6$\xab:\x9d\x8b"
+ENV PYTHONPATH=.
+ENV LD_LIBRARY_PATH=libcsp/build
 SHELL ["/bin/bash", "-c"]
-COPY update.sh . 
+COPY update.sh .
 RUN source ./update.sh
 RUN rm update.sh
 

--- a/env.sh
+++ b/env.sh
@@ -4,3 +4,5 @@ export FLASK_APP=groundstation/__init__.py
 export FLASK_ENV=development
 export APP_SETTINGS=groundstation.config.DevelopmentConfig
 export SECRET_KEY="\xffY\x8dG\xfbu\x96S\x86\xdfu\x98\xe8S\x9f\x0e\xc6\xde\xb6$\xab:\x9d\x8b"
+export LD_LIBRARY_PATH="libcsp/build"
+export PYTHONPATH="."

--- a/groundstation/static/js/components/LiveCommands.jsx
+++ b/groundstation/static/js/components/LiveCommands.jsx
@@ -119,9 +119,10 @@ class LiveCommands extends Component {
 
 
     telecommandIsValid(telecommand_string) {
-        const split_string = telecommand_string.substring(4).trim().split(' ');
+        const split_string = telecommand_string.trim().split(' ');
         const matching_command = this.state.validTelecommands.find((element) => {
-            if (element.command_name === split_string[0]) {
+            if (element.command_name === split_string[0]
+                || element.command_name === split_string[0].substring(4)) {
                 return element
             }
         });

--- a/groundstation/static/js/components/LiveCommands.jsx
+++ b/groundstation/static/js/components/LiveCommands.jsx
@@ -119,7 +119,7 @@ class LiveCommands extends Component {
 
 
     telecommandIsValid(telecommand_string) {
-        const split_string = telecommand_string.trim().split(' ');
+        const split_string = telecommand_string.substring(4).trim().split(' ');
         const matching_command = this.state.validTelecommands.find((element) => {
             if (element.command_name === split_string[0]) {
                 return element

--- a/groundstation/tests/groundstation_test.py
+++ b/groundstation/tests/groundstation_test.py
@@ -4,9 +4,14 @@ from comm import convert_command_syntax
 from groundstation.tests.base import BaseTestCase
 import ex2_ground_station_software.src.groundStation as gs_software
 
+"""These tests must be run manually by
+	`python3 manage.py test groundstation_test`
+after running `source ./update.sh` and building libcsp in this repo.
+"""
+
 # List of commands to test ground_station_software's DUMMY responses
 # FORMAT:
-# (command (website format), expected server, expected port, expected buffer as bytestring)
+# (command (website format), expected server, expected port, expected buffer)
 commands = [
 	("obc.time_management.get_time", 1, 8, b'\n'),
 	("obc.time_management.set_time 1234567890", 1, 8, b'\x0bI\x96\x02\xd2'),
@@ -18,6 +23,8 @@ commands = [
 ]
 
 class Options():
+	"""Dummy container to store ground station options.
+	"""
 	pass
 
 class TestGroundstation(BaseTestCase):
@@ -28,7 +35,7 @@ class TestGroundstation(BaseTestCase):
 		opts.timeout = 10000
 		cls.gs = gs_software.groundStation.groundStation(opts)
 
-	def test_syntax_converter(self):
+	def test_command_converter(self):
 		with self.subTest(c="obc.time_management.get_time"):
 			web_command = "obc.time_management.get_time"
 			self.assertEqual("obc.time_management.get_time()", convert_command_syntax(web_command))

--- a/groundstation/tests/groundstation_test.py
+++ b/groundstation/tests/groundstation_test.py
@@ -5,7 +5,7 @@ from groundstation.tests.base import BaseTestCase
 import ex2_ground_station_software.src.groundStation as gs_software
 
 """These tests must be run manually by
-	`python3 manage.py test groundstation_test`
+    `python3 manage.py test groundstation_test`
 after running `source ./update.sh` and building libcsp in this repo.
 """
 
@@ -13,54 +13,54 @@ after running `source ./update.sh` and building libcsp in this repo.
 # FORMAT:
 # (command (website format), expected server, expected port, expected buffer)
 commands = [
-	("obc.time_management.get_time", 1, 8, b'\n'),
-	("obc.time_management.set_time 1234567890", 1, 8, b'\x0bI\x96\x02\xd2'),
-	("eps.time_management.get_eps_time", 4, 8, b'\x00'),
-	("eps.control.single_output_control 10 0 0", 4, 14, b'\x00\n\x00\x00\x00'),
-	("eps.configuration.get_active_config 136 2", 4, 9, b'\x00\x88\x00\x02'),
-	("obc.updater.get_app_info", 1, 12, b'\x02'),
-	("obc.updater.set_app_address 2097152", 1, 12, b'\x03\x00 \x00\x00')
+    ("obc.time_management.get_time", 1, 8, b'\n'),
+    ("obc.time_management.set_time 1234567890", 1, 8, b'\x0bI\x96\x02\xd2'),
+    ("eps.time_management.get_eps_time", 4, 8, b'\x00'),
+    ("eps.control.single_output_control 10 0 0", 4, 14, b'\x00\n\x00\x00\x00'),
+    ("eps.configuration.get_active_config 136 2", 4, 9, b'\x00\x88\x00\x02'),
+    ("obc.updater.get_app_info", 1, 12, b'\x02'),
+    ("obc.updater.set_app_address 2097152", 1, 12, b'\x03\x00 \x00\x00')
 ]
 
 class Options():
-	"""Dummy container to store ground station options.
-	"""
-	pass
+    """Dummy container to store ground station options.
+    """
+    pass
 
 class TestGroundstation(BaseTestCase):
-	@classmethod
-	def setUpClass(cls):
-		opts = Options()
-		opts.interface = 'dummy'
-		opts.timeout = 10000
-		cls.gs = gs_software.groundStation.groundStation(opts)
+    @classmethod
+    def setUpClass(cls):
+        opts = Options()
+        opts.interface = 'dummy'
+        opts.timeout = 10000
+        cls.gs = gs_software.groundStation.groundStation(opts)
 
-	def test_command_converter(self):
-		with self.subTest(c="obc.time_management.get_time"):
-			web_command = "obc.time_management.get_time"
-			self.assertEqual("obc.time_management.get_time()", convert_command_syntax(web_command))
-		with self.subTest(c="obc.time_management.set_time 123456789"):
-			web_command = "obc.time_management.set_time 123456789"
-			self.assertEqual("obc.time_management.set_time(123456789)", convert_command_syntax(web_command))
-		with self.subTest(c="eps.configuration.get_active_config 136 2"):
-			web_command = "eps.configuration.get_active_config 136 2"
-			self.assertEqual("eps.configuration.get_active_config(136 2)", convert_command_syntax(web_command))
-		with self.subTest(c="eps.control.single_output_control 10 0 0"):
-			web_command = "eps.control.single_output_control 10 0 0"
-			self.assertEqual("eps.control.single_output_control(10 0 0)", convert_command_syntax(web_command))
+    def test_command_converter(self):
+        with self.subTest(c="obc.time_management.get_time"):
+            web_command = "obc.time_management.get_time"
+            self.assertEqual("obc.time_management.get_time()", convert_command_syntax(web_command))
+        with self.subTest(c="obc.time_management.set_time 123456789"):
+            web_command = "obc.time_management.set_time 123456789"
+            self.assertEqual("obc.time_management.set_time(123456789)", convert_command_syntax(web_command))
+        with self.subTest(c="eps.configuration.get_active_config 136 2"):
+            web_command = "eps.configuration.get_active_config 136 2"
+            self.assertEqual("eps.configuration.get_active_config(136 2)", convert_command_syntax(web_command))
+        with self.subTest(c="eps.control.single_output_control 10 0 0"):
+            web_command = "eps.control.single_output_control 10 0 0"
+            self.assertEqual("eps.control.single_output_control(10 0 0)", convert_command_syntax(web_command))
 
-	def test_gs_commands(self):
-		for c in commands:
-			with self.subTest(c=c):
-				gs_command = convert_command_syntax(c[0])
-				server, port, toSend = self.gs.getInput(inVal=gs_command)
-				resp = self.gs.transaction(server, port, toSend)
-				with self.subTest():
-					self.assertEqual(resp[0]["Server"], c[1])
-				with self.subTest():
-					self.assertEqual(resp[0]["Port"], c[2])
-				with self.subTest():
-					self.assertEqual(resp[0]["Buffer"], c[3])
+    def test_gs_commands(self):
+        for c in commands:
+            with self.subTest(c=c):
+                gs_command = convert_command_syntax(c[0])
+                server, port, toSend = self.gs.getInput(inVal=gs_command)
+                resp = self.gs.transaction(server, port, toSend)
+                with self.subTest():
+                    self.assertEqual(resp[0]["Server"], c[1])
+                with self.subTest():
+                    self.assertEqual(resp[0]["Port"], c[2])
+                with self.subTest():
+                    self.assertEqual(resp[0]["Buffer"], c[3])
 
 if __name__ == '__main__':
     unittest.main()

--- a/groundstation/tests/test_groundstation.py
+++ b/groundstation/tests/test_groundstation.py
@@ -1,19 +1,20 @@
 import unittest
 
+from comm import convert_command_syntax
 from groundstation.tests.base import BaseTestCase
 import ex2_ground_station_software.src.groundStation as gs_software
 
 # List of commands to test ground_station_software's DUMMY responses
 # FORMAT:
-# (command, expected server, expected port, expected buffer as bytestring)
+# (command (website format), expected server, expected port, expected buffer as bytestring)
 commands = [
-	("obc.time_management.get_time()", 1, 8, b'\n'),
-	("obc.time_management.set_time(1234567890)", 1, 8, b'\x0bI\x96\x02\xd2'),
-	("eps.time_management.get_eps_time()", 4, 8, b'\x00'),
-	("eps.control.single_output_control(10 0 0)", 4, 14, b'\x00\n\x00\x00\x00'),
-	("eps.configuration.get_active_config(136 2)", 4, 9, b'\x00\x88\x00\x02'),
-	("obc.updater.get_app_info()", 1, 12, b'\x02'),
-	("obc.updater.set_app_address(2097152)", 1, 12, b'\x03\x00 \x00\x00')
+	("obc.time_management.get_time", 1, 8, b'\n'),
+	("obc.time_management.set_time 1234567890", 1, 8, b'\x0bI\x96\x02\xd2'),
+	("eps.time_management.get_eps_time", 4, 8, b'\x00'),
+	("eps.control.single_output_control 10 0 0", 4, 14, b'\x00\n\x00\x00\x00'),
+	("eps.configuration.get_active_config 136 2", 4, 9, b'\x00\x88\x00\x02'),
+	("obc.updater.get_app_info", 1, 12, b'\x02'),
+	("obc.updater.set_app_address 2097152", 1, 12, b'\x03\x00 \x00\x00')
 ]
 
 class Options():
@@ -27,10 +28,25 @@ class TestGroundstation(BaseTestCase):
 		opts.timeout = 10000
 		cls.gs = gs_software.groundStation.groundStation(opts)
 
+	def test_syntax_converter(self):
+		with self.subTest(c="obc.time_management.get_time"):
+			web_command = "obc.time_management.get_time"
+			self.assertEqual("obc.time_management.get_time()", convert_command_syntax(web_command))
+		with self.subTest(c="obc.time_management.set_time 123456789"):
+			web_command = "obc.time_management.set_time 123456789"
+			self.assertEqual("obc.time_management.set_time(123456789)", convert_command_syntax(web_command))
+		with self.subTest(c="eps.configuration.get_active_config 136 2"):
+			web_command = "eps.configuration.get_active_config 136 2"
+			self.assertEqual("eps.configuration.get_active_config(136 2)", convert_command_syntax(web_command))
+		with self.subTest(c="eps.control.single_output_control 10 0 0"):
+			web_command = "eps.control.single_output_control 10 0 0"
+			self.assertEqual("eps.control.single_output_control(10 0 0)", convert_command_syntax(web_command))
+
 	def test_gs_commands(self):
 		for c in commands:
 			with self.subTest(c=c):
-				server, port, toSend = self.gs.getInput(inVal=c[0])
+				gs_command = convert_command_syntax(c[0])
+				server, port, toSend = self.gs.getInput(inVal=gs_command)
 				resp = self.gs.transaction(server, port, toSend)
 				with self.subTest():
 					self.assertEqual(resp[0]["Server"], c[1])

--- a/groundstation/tests/test_groundstation.py
+++ b/groundstation/tests/test_groundstation.py
@@ -1,17 +1,43 @@
 import unittest
 
 from groundstation.tests.base import BaseTestCase
+import ex2_ground_station_software.src.groundStation as gs_software
+
+# List of commands to test ground_station_software's DUMMY responses
+# FORMAT:
+# (command, expected server, expected port, expected buffer as bytestring)
+commands = [
+	("obc.time_management.get_time()", 1, 8, b'\n'),
+	("obc.time_management.set_time(1234567890)", 1, 8, b'\x0bI\x96\x02\xd2'),
+	("eps.time_management.get_eps_time()", 4, 8, b'\x00'),
+	("eps.control.single_output_control(10 0 0)", 4, 14, b'\x00\n\x00\x00\x00'),
+	("eps.configuration.get_active_config(136 2)", 4, 9, b'\x00\x88\x00\x02'),
+	("obc.updater.get_app_info()", 1, 12, b'\x02'),
+	("obc.updater.set_app_address(2097152)", 1, 12, b'\x03\x00 \x00\x00')
+]
+
+class Options():
+	pass
 
 class TestGroundstation(BaseTestCase):
-	"""Test the testing"""
-	def testTesting(self):
-		self.assertEqual(200, 200)
-	
-	def test_interface(self):
-		# Don't know how to write this test TBH
-		pass
+	@classmethod
+	def setUpClass(cls):
+		opts = Options()
+		opts.interface = 'dummy'
+		opts.timeout = 10000
+		cls.gs = gs_software.groundStation.groundStation(opts)
 
-
+	def test_gs_commands(self):
+		for c in commands:
+			with self.subTest(c=c):
+				server, port, toSend = self.gs.getInput(inVal=c[0])
+				resp = self.gs.transaction(server, port, toSend)
+				with self.subTest():
+					self.assertEqual(resp[0]["Server"], c[1])
+				with self.subTest():
+					self.assertEqual(resp[0]["Port"], c[2])
+				with self.subTest():
+					self.assertEqual(resp[0]["Buffer"], c[3])
 
 if __name__ == '__main__':
     unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ marshmallow==3.2.1
 numpy==1.22.2
 psycopg2-binary==2.8.6
 pycparser==2.20
+pyserial==3.5
 python-dateutil==2.8.0
 python-editor==1.0.4
 pytz==2019.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ Jinja2==2.11.3
 Mako==1.1.0
 MarkupSafe==1.1.1
 marshmallow==3.2.1
+numpy==1.22.2
 psycopg2-binary==2.8.6
 pycparser==2.20
 python-dateutil==2.8.0

--- a/user.Dockerfile
+++ b/user.Dockerfile
@@ -11,7 +11,12 @@ RUN apt-get update && apt-get install -y \
   curl \
   git \
   libpq-dev \
-  libffi-dev
+  libffi-dev \
+  libzmq3-dev \
+  libsocketcan-dev \
+  pkg-config \
+  gcc-multilib \
+  g++-multilib
 
 # install python
 RUN apt-get update && apt-get install -y \
@@ -27,6 +32,10 @@ WORKDIR /home/ex2_ground_station_website
 COPY . .
 RUN pip3 install -r requirements.txt
 
+# build libcsp
+WORKDIR /home/ex2_ground_station_website
+RUN ./build_libcsp.sh
+
 # install node.js & npm
 WORKDIR /home
 RUN apt-get update && apt-get install -y \
@@ -39,6 +48,8 @@ ENV FLASK_APP=groundstation/__init__.py
 ENV FLASK_ENV=development
 ENV APP_SETTINGS=groundstation.config.DevelopmentConfig
 ENV SECRET_KEY="\xffY\x8dG\xfbu\x96S\x86\xdfu\x98\xe8S\x9f\x0e\xc6\xde\xb6$\xab:\x9d\x8b"
+ENV LD_LIBRARY_PATH=libcsp/build
+ENV PYTHONPATH=.
 SHELL ["/bin/bash", "-c"]
 RUN source ./update.sh
 


### PR DESCRIPTION
- Updated imports in ex2_ground_station_software to handle integration in comm.py
- comm.py now uses groundStation.transaction() instead of receive() to transmit command to mimic the software's cli
    - Not sure if we need to keep libcsp (and keep a libcsp socket open) directly in comm.py as gs_software handles it already.
- comm.py can now be run with the same cli arguments as groundStation.py
    - eg. `python3 comm.py -I uart -d /dev/ttyUSB0` (will add this to wiki once merged)
    - Note: Need to build libcsp in the submodule and need to run `source ./env.sh` for comm.py integration with gs_software to work