### PR TITLE
added argument labels to help page

### DIFF
--- a/groundstation/backend_api/models.py
+++ b/groundstation/backend_api/models.py
@@ -109,6 +109,7 @@ class Telecommands(db.Model):
         'AutomatedCommands', backref='command', lazy=True)
     is_dangerous = db.Column(db.Boolean)
     about_info = db.Column(db.String(256))
+    arg_labels = db.Column(db.String(400))
 
     def to_json(self):
         """Returns a dictionary of some selected model attributes
@@ -118,7 +119,8 @@ class Telecommands(db.Model):
             'command_name': self.command_name,
             'num_arguments': self.num_arguments,
             'is_dangerous': self.is_dangerous,
-            'about_info': self.about_info
+            'about_info': self.about_info,
+            'arg_labels': self.arg_labels
         }
 
 
@@ -228,6 +230,8 @@ class Passover(db.Model):
 # This will be the table of telecommands being sent to the satellite as well as the responses
 # the table will allow us to send and receive all commands transactionally allowing us to log
 # them as well as their responses
+
+
 class Communications(db.Model):
     __tablename__ = 'communications'
 
@@ -805,7 +809,8 @@ class EpsStartupHK(db.Model):
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     hk_id = db.Column(db.Integer, db.ForeignKey('housekeeping.id'))
-    hk = db.relationship('Housekeeping', backref=backref('eps_startup', uselist=False))
+    hk = db.relationship('Housekeeping', backref=backref(
+        'eps_startup', uselist=False))
 
     eps_cmd_startup = db.Column(db.Integer)
     eps_status_startup = db.Column(db.Integer)

--- a/groundstation/backend_api/utils.py
+++ b/groundstation/backend_api/utils.py
@@ -31,7 +31,7 @@ def create_context(function):
     return decorate
 
 
-def add_telecommand(command_name, num_arguments, is_dangerous, about_info=None):
+def add_telecommand(command_name, num_arguments, is_dangerous, about_info=None, arg_labels=None):
     """Add a new telecommand to the database
     """
     # only add command if it isn't already in the database
@@ -39,7 +39,7 @@ def add_telecommand(command_name, num_arguments, is_dangerous, about_info=None):
         Telecommands.command_name == command_name).first()
     if not command:
         command = Telecommands(command_name=command_name, num_arguments=num_arguments,
-                               is_dangerous=is_dangerous, about_info=about_info)
+                               is_dangerous=is_dangerous, about_info=about_info, arg_labels=arg_labels)
 
         db.session.add(command)
         db.session.commit()

--- a/groundstation/static/js/components/Help.jsx
+++ b/groundstation/static/js/components/Help.jsx
@@ -366,6 +366,11 @@ const Help = () => {
                   {command.about_info != null ? (
                     <p style={{ paddingLeft: '5%' }}>{command.about_info}</p>
                   ) : null}
+                  {command.arg_labels != null ? (
+                    <p style={{ paddingLeft: '5%' }}>
+                      {'Arguments: ' + command.arg_labels}
+                    </p>
+                  ) : null}
                   <hr></hr>
                 </Typography>
               ) : null

--- a/manage.py
+++ b/manage.py
@@ -288,20 +288,26 @@ def import_commands():
             sub = subservice[subName]
             inoutInfo = sub['inoutInfo']
             info = 'Not yet available' if not 'what' in sub else sub['what']
+            
             if inoutInfo['args'] is None:
                 num_arguments = 0
+                arg_list=None
             else:
                 num_arguments = len(inoutInfo['args'])
-
+                arg_list=''
+                for arg in inoutInfo['args'].keys():
+                    arg_list = arg_list + str(arg) + ', '
+                arg_list = arg_list[:-2]
+                
             is_dangerous = False
             for i, prefix in enumerate(supported_prefixes):
                 if i == 0:
                     # Only one 'copy' of a command needs the about_info
                     add_telecommand(command_name=(prefix + '.' + serv + '.' + subName).lower(), num_arguments=num_arguments,
-                                    is_dangerous=is_dangerous, about_info=info)
+                                    is_dangerous=is_dangerous, about_info=info, arg_labels=arg_list)
                 else:
                     add_telecommand(command_name=(prefix + '.' + serv + '.' + subName).lower(), num_arguments=num_arguments,
-                                    is_dangerous=is_dangerous, about_info=None)
+                                    is_dangerous=is_dangerous, about_info=None, arg_labels=None)
 
     print("Added new telecommands.")
 


### PR DESCRIPTION
I'm not sure if we wanted similar thing for what each command returns. Could be displayed in the same sort of way on help page